### PR TITLE
Support Frame construction without optimization (#503)

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -10,7 +10,7 @@ function _precompile_()
               evaluate_primitivetype)
         @assert precompile(Tuple{typeof(f), Any, Frame, Expr})
     end
-    @assert precompile(Tuple{typeof(evaluate_foreigncall), Frame, Expr})
+    @assert precompile(Tuple{typeof(evaluate_foreigncall), Any, Frame, Expr})
     @assert precompile(Tuple{typeof(evaluate_methoddef), Frame, Expr})
     @assert precompile(Tuple{typeof(lookup_global_refs!), Expr})
     @assert precompile(Tuple{typeof(lookup_or_eval), Any, Frame, Any})

--- a/src/types.jl
+++ b/src/types.jl
@@ -250,12 +250,12 @@ function Frame(framecode::FrameCode, framedata::FrameData, pc=1, caller=nothing)
     end
 end
 """
-    frame = Frame(mod::Module, src::CodeInfo)
+    frame = Frame(mod::Module, src::CodeInfo; kwargs...)
 
 Construct a `Frame` to evaluate `src` in module `mod`.
 """
-function Frame(mod::Module, src::CodeInfo)
-    framecode = FrameCode(mod, src)
+function Frame(mod::Module, src::CodeInfo; kwargs...)
+    framecode = FrameCode(mod, src; kwargs...)
     return Frame(framecode, prepare_framedata(framecode, []))
 end
 """


### PR DESCRIPTION
The main challenge is to support nested calls. Now that `FrameData.callargs` is not shared across frames, this is doable.

Co-authored-by: Kristoffer Carlsson <kcarlsson89@gmail.com>
Co-authored-by: Shuhei Kadowaki <40514306+aviatesk@users.noreply.github.com>